### PR TITLE
changed libsmt to report more information back to rustproof.

### DIFF
--- a/src/backends/backend.rs
+++ b/src/backends/backend.rs
@@ -15,6 +15,14 @@ pub enum SMTError {
     AssertionError(String),
 }
 
+#[derive(Clone, Debug)]
+pub enum SMTRes {
+    Sat(String),
+    Unsat(String),
+    Error(String),
+}
+
+
 pub type SMTResult<T> = Result<T, SMTError>;
 
 /// Trait a backend should implement to support SMT solving.
@@ -50,14 +58,14 @@ pub trait SMTBackend {
               P: Into<<<Self as SMTBackend>::Logic as Logic>::Sorts>;
 
     fn assert<T: Into<<<Self as SMTBackend>::Logic as Logic>::Fns>>(&mut self, T, &[Self::Idx]) -> Self::Idx;
-    fn check_sat<S: SMTProc>(&mut self, &mut S) -> bool;
-    fn solve<S: SMTProc>(&mut self, &mut S) -> SMTResult<HashMap<Self::Idx, u64>>;
+    fn check_sat<S: SMTProc>(&mut self, &mut S) -> SMTRes;
+    fn solve<S: SMTProc>(&mut self, &mut S) -> (SMTResult<HashMap<Self::Idx, u64>>, SMTRes);
 }
 
 pub trait Logic: fmt::Display + Clone + Copy {
     type Fns: SMTNode + fmt::Display + Debug + Clone;
     type Sorts: fmt::Display + Debug + Clone;
-    
+
     fn free_var<T: AsRef<str>>(T, Self::Sorts) -> Self::Fns;
 }
 

--- a/src/backends/z3.rs
+++ b/src/backends/z3.rs
@@ -1,7 +1,26 @@
 //! Struct and methods to interact with the Z3 solver.
 
+
+//extern crate native;
+//extern crate rustrt;
+
+//use std::io::{process, Command};
+//use native::io::file;
+///use rustrt::rtio;
+
+// for file
+/*
+use std::error::Error;
+use std::io::prelude::*;
+use std::fs::File;
+use std::os::unix::io::IntoRawFd;
+use std::path::Path;
+*/
+//f2
+
 use backends::smtlib2::SMTProc;
 use std::process::{Child, Command, Stdio};
+
 
 #[derive(Default)]
 pub struct Z3 {
@@ -18,6 +37,7 @@ impl SMTProc for Z3 {
                         .stderr(Stdio::piped())
                         .spawn()
                         .expect("Failed to spawn process");
+
         self.fd = Some(child);
     }
 


### PR DESCRIPTION
libsmt now returns the full z3 output (atleas on unix... needs win32 testing)
added an z3 exit code to report z3 exit status
changed return type of some functions to support new return status
